### PR TITLE
Fix store stock and user balance

### DIFF
--- a/priv/repo/migrations/20220412014450_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20220412014450_create_users_auth_tables.exs
@@ -29,6 +29,8 @@ defmodule Parzival.Repo.Migrations.CreateUsersAuthTables do
 
     create unique_index(:users, [:email])
 
+    create constraint(:users, :balance_must_be_positive, check: "balance >= 0")
+
     create table(:users_tokens, primary_key: false) do
       add :id, :binary_id, primary_key: true
       add :user_id, references(:users, type: :binary_id, on_delete: :delete_all), null: false

--- a/priv/repo/migrations/20220422162950_create_products.exs
+++ b/priv/repo/migrations/20220422162950_create_products.exs
@@ -15,5 +15,7 @@ defmodule Parzival.Repo.Migrations.CreateProducts do
 
       timestamps()
     end
+
+    create constraint(:products, :stock_must_be_positive, check: "stock >= 0")
   end
 end


### PR DESCRIPTION
While talking with @nelsonmestevao, we noticed that the user could have a balance under zero, allowing the user to purchase more things than he was allowed. And the store could also have a stock under zero.

We added a constraint to enforce this would not happen.