### PR TITLE
Fix mission page overlay in chrome and edge browsers

### DIFF
--- a/lib/parzival_web/live/landing/missions_live/index.html.heex
+++ b/lib/parzival_web/live/landing/missions_live/index.html.heex
@@ -5,7 +5,7 @@
         Missions
       </span>
     </div>
-    <div class="mr-10 ml-20 font-extrabold leading-none text-white uppercase md:ml-36 2xl:mx-80 text-[35px] sm:text-[60px] lg:ml-[240px] lg:text-[78px] xl:text-[90px]">
+    <div class="mr-10 ml-20 font-extrabold leading-none text-white uppercase md:ml-36 2xl:mx-80 text-[35px] sm:text-[60px] lg:ml-[240px] lg:text-[78px] xl:text-[85px]">
       Complete missions, gain experience, earn <span class="underline decoration-4 sm:decoration-8">rewards</span>.
     </div>
   </div>


### PR DESCRIPTION
### Before [chrome&&edge]
![join overlay](https://user-images.githubusercontent.com/61701003/174286098-f8defe1d-5dbc-4fda-a495-bb4167382af0.png)

### After [chrome&&edge]
![image](https://user-images.githubusercontent.com/61701003/174286422-c2d33390-e247-4098-89cd-2e1f91614cbe.png)
