### PR TITLE
Fix dashboard entry on mobile navbar

### DIFF
--- a/lib/parzival_web/templates/layout/_mobile_live_navbar.html.heex
+++ b/lib/parzival_web/templates/layout/_mobile_live_navbar.html.heex
@@ -31,7 +31,7 @@
       </button>
     </div>
 
-    <div class="flex flex-col gap-y-8 justify-center items-center px-4 my-14 mx-auto w-full overflow-scroll h-[70%]">
+    <div class="flex flex-col gap-y-8 items-center px-4 my-14 mx-auto w-full overflow-scroll h-[70%]">
       <%= for page <- ParzivalWeb.Config.pages(@socket, @current_user) do %>
         <%= if page.tabs != [] do %>
           <div class="relative w-full" x-data="{ open: false }" @click.away="open = false">


### PR DESCRIPTION
**After:**

![image](https://user-images.githubusercontent.com/76881129/175785285-c3ad772b-0aee-4908-9441-17325ed77ec1.png)

Closes #187.