### PR TITLE
Add pagination to users who completed mission table

### DIFF
--- a/lib/parzival/gamification/mission/mission_user.ex
+++ b/lib/parzival/gamification/mission/mission_user.ex
@@ -9,6 +9,15 @@ defmodule Parzival.Gamification.Mission.MissionUser do
 
   @required_fields ~w(user_id mission_id)a
 
+  @derive {
+    Flop.Schema,
+    filterable: [],
+    sortable: [:inserted_at],
+    compound_fields: [],
+    default_order_by: [:inserted_at],
+    default_order_directions: [:desc]
+  }
+
   schema "missions_users" do
     belongs_to :mission, Mission
     belongs_to :user, User

--- a/lib/parzival_web/components/pagination.ex
+++ b/lib/parzival_web/components/pagination.ex
@@ -11,11 +11,12 @@ defmodule ParzivalWeb.Components.Pagination do
         <div class="flex flex-1 -mt-px w-0">
           <%= if @meta.has_previous_page? do %>
             <%= live_patch to: build_query(@meta.previous_page, @params), class: "inline-flex items-center pt-4 pr-1 text-sm font-medium text-gray-500 hover:text-gray-700" do %>
-              <Heroicons.Solid.arrow_narrow_left class="mr-3 w-5 h-5 text-gray-400" /> Previous
+              <Heroicons.Solid.arrow_narrow_left class="mr-3 w-5 h-5 text-gray-400" />
+              <p class="hidden sm:flex">Previous</p>
             <% end %>
           <% end %>
         </div>
-        <div class="hidden lg:flex lg:-mt-px">
+        <div class="flex lg:-mt-px">
           <%= if max(1, @meta.current_page - 2) != 1 do %>
             <%= live_patch("1", to: build_query(1, @params), class: "inline-flex items-center px-4 pt-4 text-sm font-medium text-gray-500 hover:text-gray-700 ") %>
 
@@ -46,7 +47,8 @@ defmodule ParzivalWeb.Components.Pagination do
         <div class="flex flex-1 justify-end -mt-px w-0">
           <%= if @meta.has_next_page? do %>
             <%= live_patch to: build_query(@meta.next_page, @params), class: "inline-flex items-center pt-4 pl-1 text-sm font-medium text-gray-500 hover:text-gray-700" do %>
-              Next <Heroicons.Solid.arrow_narrow_right class="ml-3 w-5 h-5 text-gray-400" />
+              <p class="hidden sm:flex">Next</p>
+               <Heroicons.Solid.arrow_narrow_right class="ml-3 w-5 h-5 text-gray-400" />
             <% end %>
           <% end %>
         </div>

--- a/lib/parzival_web/live/app/gamification/mission_live/show.ex
+++ b/lib/parzival_web/live/app/gamification/mission_live/show.ex
@@ -2,6 +2,8 @@ defmodule ParzivalWeb.App.MissionLive.Show do
   @moduledoc false
   use ParzivalWeb, :live_view
 
+  import ParzivalWeb.Components.Pagination
+
   alias Parzival.Accounts
   alias Parzival.Gamification
 
@@ -15,10 +17,11 @@ defmodule ParzivalWeb.App.MissionLive.Show do
   end
 
   @impl true
-  def handle_params(%{"id" => _id}, _, socket) do
+  def handle_params(params, _, socket) do
     socket =
       socket
       |> assign(:current_page, :missions)
+      |> assign(:params, params)
       |> assign(:page_title, "Show Mission")
       |> assign(:attendees_count, Accounts.count_users(where: [role: :attendee]))
 
@@ -49,6 +52,7 @@ defmodule ParzivalWeb.App.MissionLive.Show do
 
   defp reload(socket) do
     id = socket.assigns.id
+    params = socket.assigns.params
 
     socket
     |> assign(
@@ -56,14 +60,23 @@ defmodule ParzivalWeb.App.MissionLive.Show do
       Gamification.get_mission!(id, [:difficulty, :created_by, tasks: [:users]])
     )
     |> assign(:count_mission_users, Gamification.count_missions_users(where: [mission_id: id]))
-    |> assign(
-      :mission_users,
-      Gamification.list_missions_users(
-        where: [mission_id: id],
-        limit: 12,
-        order_by: [:inserted_at],
-        preloads: [user: :missions]
-      )
-    )
+    |> assign(list_completed_missions_users(params))
+  end
+
+  defp list_completed_missions_users(%{"id" => id} = params) do
+    params =
+      params
+      |> Map.put("page_size", 12)
+
+    case Gamification.list_missions_users(params,
+           preloads: [user: :missions],
+           where: [mission_id: id]
+         ) do
+      {:ok, {mission_users, meta}} ->
+        %{mission_users: mission_users, meta: meta}
+
+      {:error, flop} ->
+        %{mission_users: [], meta: flop}
+    end
   end
 end

--- a/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
+++ b/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
@@ -153,7 +153,7 @@
     <a @click="last_users = !last_users" class="cursor-pointer hover:bg-gray-50">
       <div class="flex flex-row justify-between items-center py-6 px-4 border-b border-gray-200 sm:px-6 lg:px-8">
         <h2 class="text-lg font-medium sm:text-xl">
-          Last users that completed this mission
+          Users that completed this mission
         </h2>
         <Heroicons.Solid.chevron_right x-bind:class="last_users?'rotate-90' : 'rotate-0'" class="w-6 h-6 text-black" />
       </div>

--- a/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
+++ b/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
@@ -187,8 +187,10 @@
         <% end %>
       <% end %>
     </div>
-    <div x-bind:class="last_users?'flex' : 'hidden'">
-      <.pagination items={@mission_users} meta={@meta} params={@params} class="flex justify-between items-center w-full" />
-    </div>
+    <%= if length(@mission_users) > 0 do %>
+      <div x-bind:class="last_users?'flex' : 'hidden'">
+        <.pagination items={@mission_users} meta={@meta} params={@params} class="flex justify-between items-center w-full" />
+      </div>
+    <% end %>
   </div>
 </div>

--- a/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
+++ b/lib/parzival_web/live/app/gamification/mission_live/show.html.heex
@@ -187,5 +187,8 @@
         <% end %>
       <% end %>
     </div>
+    <div x-bind:class="last_users?'flex' : 'hidden'">
+      <.pagination items={@mission_users} meta={@meta} params={@params} class="flex justify-between items-center w-full" />
+    </div>
   </div>
 </div>

--- a/lib/parzival_web/live/app/gamification/task_live/show.html.heex
+++ b/lib/parzival_web/live/app/gamification/task_live/show.html.heex
@@ -74,7 +74,7 @@
   <div class="flex flex-col mx-auto w-full">
     <div class="flex flex-row justify-between items-center py-6 px-4 border-b border-gray-200 sm:px-6 lg:px-8">
       <h2 class="text-lg font-medium sm:text-xl">
-        Last users that completed this task
+        Users that completed this task
       </h2>
     </div>
     <div>

--- a/lib/parzival_web/live/app/gamification/task_live/show.html.heex
+++ b/lib/parzival_web/live/app/gamification/task_live/show.html.heex
@@ -107,7 +107,9 @@
           <% end %>
         <% end %>
       </ul>
-      <.pagination items={@task_users} meta={@meta} params={@params} class="flex justify-between items-center w-full" />
+      <%= if length(@task_users) > 0 do %>
+        <.pagination items={@task_users} meta={@meta} params={@params} class="flex justify-between items-center w-full" />
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds pagination to the users that completed mission table in the mission show page. Also hides pagination when there are no entries.

![image](https://user-images.githubusercontent.com/30907944/226595557-281b598d-e484-41d0-ac45-390a325e98e3.png)
