### PR TITLE
Add work model field to job offers

### DIFF
--- a/lib/parzival/companies/offer.ex
+++ b/lib/parzival/companies/offer.ex
@@ -9,9 +9,11 @@ defmodule Parzival.Companies.Offer do
   alias Parzival.Companies.OfferTime
   alias Parzival.Companies.OfferType
 
-  @required_fields ~w(maximum_salary minimum_salary title location description company_id offer_type_id offer_time_id)a
+  @required_fields ~w(maximum_salary minimum_salary title location work_model description company_id offer_type_id offer_time_id)a
 
   @optional_fields []
+
+  @work_models ~w(remote hybrid on_site)a
 
   @derive {
     Flop.Schema,
@@ -27,6 +29,7 @@ defmodule Parzival.Companies.Offer do
     field :minimum_salary, :integer
     field :title, :string
     field :location, :string
+    field :work_model, Ecto.Enum, values: @work_models
     field :description, :string
 
     field :applied, :integer, virtual: true

--- a/lib/parzival_web/live/app/jobs/offer_live/form_component.html.heex
+++ b/lib/parzival_web/live/app/jobs/offer_live/form_component.html.heex
@@ -45,6 +45,10 @@
             <Heroicons.Solid.location_marker class="flex-shrink-0 mr-1.5 w-5 h-5 text-gray-400" />
             <%= text_input(f, :location, placeholder: "Choose location", phx_debounce: "blur", class: "mt-1 focus:ring-red-500 focus:border-red-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md") %>
           </div>
+          <div class="flex items-center mt-2 text-sm text-gray-500">
+            <Heroicons.Solid.users class="flex-shrink-0 mr-1.5 w-5 h-5 text-gray-400" />
+            <%= select(f, :work_model, [[key: "Remote", value: :remote], [key: "Hybrid", value: :hybrid], [key: "On-site", value: :on_site]], prompt: "Choose a work model", selected: f.data.work_model, class: "block border-gray-300 rounded-md shadow-sm focus:ring-red-800 focus:border-red-800") %>
+          </div>
           <div class="flex text-red-500">
             <%= error_tag(f, :location) %>
           </div>

--- a/lib/parzival_web/live/app/jobs/offer_live/index.html.heex
+++ b/lib/parzival_web/live/app/jobs/offer_live/index.html.heex
@@ -63,7 +63,7 @@
                     <div class="flex flex-col lg:flex-row">
                       <p class="flex items-center mr-5 text-sm text-gray-500">
                         <Heroicons.Solid.location_marker class="flex-shrink-0 mr-0.5 w-5 h-5 text-gray-400" />
-                        <%= offer.location %>
+                        <%= offer.location %> (<%= offer.work_model |> to_string() |> String.replace("_", "-") |> String.capitalize() %>)
                       </p>
                       <p class="flex items-center text-sm text-gray-500">
                         <Heroicons.Solid.currency_euro class="flex-shrink-0 mr-0.5 w-5 h-5 text-gray-400" />

--- a/lib/parzival_web/live/app/jobs/offer_live/show.html.heex
+++ b/lib/parzival_web/live/app/jobs/offer_live/show.html.heex
@@ -46,7 +46,7 @@
         </div>
         <div class="flex items-center mt-2 text-sm text-gray-500">
           <Heroicons.Solid.location_marker class="flex-shrink-0 mr-1.5 w-5 h-5 text-gray-400" />
-          <%= @offer.location %>
+          <%= @offer.location %> (<%= @offer.work_model |> to_string() |> String.replace("_", "-") |> String.capitalize() %>)
         </div>
         <div class="flex items-center mt-2 text-sm text-gray-500">
           <Heroicons.Solid.currency_euro class="flex-shrink-0 mr-1.5 w-5 h-5 text-gray-400" />

--- a/priv/repo/migrations/20220529162141_create_offers.exs
+++ b/priv/repo/migrations/20220529162141_create_offers.exs
@@ -10,6 +10,7 @@ defmodule Parzival.Repo.Migrations.CreateOffers do
       add :minimum_salary, :integer
       add :maximum_salary, :integer
       add :location, :text
+      add :work_model, :text
       add :description, :text
 
       add :company_id, references(:companies, on_delete: :nothing, type: :binary_id)

--- a/priv/repo/seeds/offers.exs
+++ b/priv/repo/seeds/offers.exs
@@ -101,13 +101,12 @@ defmodule Parzival.Repo.Seeds.Offers do
           for _n <- 1..10 do
             minimum_salary = Enum.random(1000..3000)
 
-
             recruiters =
               User
               |> where(role: :recruiter)
               |> Repo.all()
 
-              {:ok, offer} =
+            {:ok, offer} =
               Offer.changeset(
                 %Offer{},
                 %{

--- a/priv/repo/seeds/offers.exs
+++ b/priv/repo/seeds/offers.exs
@@ -101,12 +101,13 @@ defmodule Parzival.Repo.Seeds.Offers do
           for _n <- 1..10 do
             minimum_salary = Enum.random(1000..3000)
 
+
             recruiters =
               User
               |> where(role: :recruiter)
               |> Repo.all()
 
-            {:ok, offer} =
+              {:ok, offer} =
               Offer.changeset(
                 %Offer{},
                 %{
@@ -115,6 +116,7 @@ defmodule Parzival.Repo.Seeds.Offers do
                   title: Faker.Lorem.sentence(2),
                   description: Faker.Lorem.sentence(100..300),
                   location: "#{Faker.Address.En.city()}, #{Faker.Address.En.country()}",
+                  work_model: Enum.random([:remote, :hybrid, :on_site]),
                   offer_time_id: Enum.random(offer_times).id,
                   offer_type_id: Enum.random(offer_types).id,
                   company_id: company.id


### PR DESCRIPTION
Adds a "Work Model" field to job offers. The field allows employers to specify whether the job is remote, hybrid, or on-site. I have implemented this feature using hardcoded values since these options are industry standard and do not require a separate table.
However, I would appreciate feedback on whether this implementation is acceptable, it's possible to store the possible values on a table and link the offer to it (this method is the one used for offer types and offer times).
What do you think @RuiL1904 @MarioRodrigues10 @ruioliveira02  @feliciofilipe @SimaoQuintela   ?

_Current implementation in the UI:_

![image](https://user-images.githubusercontent.com/30907944/226855508-8e3c21d7-5437-4192-9355-3c4d66399f11.png)

![image](https://user-images.githubusercontent.com/30907944/226855411-d480a86b-ba0d-4e73-8e01-1be092c21ae9.png)