### PR TITLE
Fix PDF generation not working in Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM elixir:1.13-alpine
+FROM surnet/alpine-wkhtmltopdf:3.16.2-0.12.6-full as wkhtmltopdf
+FROM elixir:1.14-alpine
 
 # Install build dependencies
 RUN apk add --no-cache build-base git python3
@@ -9,10 +10,22 @@ RUN npm install -g npx
 
 # Install pdf generation dependencies
 RUN apk add --no-cache \
-    libgcc libstdc++ libx11 glib libxrender libxext libintl \
-    ttf-dejavu ttf-droid ttf-freefont ttf-liberation
-COPY --from=madnight/alpine-wkhtmltopdf-builder:0.12.5-alpine3.10-606718795 \
-    /bin/wkhtmltopdf /bin/wkhtmltopdf
+        libstdc++ \
+        libx11 \
+        libxrender \
+        libxext \
+        libssl1.1 \
+        ca-certificates \
+        fontconfig \
+        freetype \
+        ttf-droid \
+        ttf-freefont \
+        ttf-liberation \
+        # more fonts
+        ;
+# wkhtmltopdf copy bins from ext image
+COPY --from=wkhtmltopdf /bin/wkhtmltopdf /bin/libwkhtmltox.so /bin/
+
 
 # Install imagemagick dependencies
 RUN apk add --no-cache file imagemagick


### PR DESCRIPTION
Before it was giving this error:
```
parzival_web  | Request: GET /cv/9b79a8b0-4bc8-4b9c-badb-e7372e75b084
parzival_web  | ** (exit) an exception was raised:
parzival_web  |     ** (ArgumentError) errors were found at the given arguments:
parzival_web  | 
parzival_web  |   * 1st argument: not a bitstring
parzival_web  | 
parzival_web  | This typically happens when calling Kernel.byte_size/1 with an invalid argument or when performing binary construction or binary concatenation with <> and one of the arguments is not a binary
parzival_web  |         :erlang.byte_size({:generator_failed, "Error loading shared library libssl.so.1.1: No such file or directory (needed by /bin/wkhtmltopdf)\nError loading shared library libcrypto.so.1.1: No such file or directory (needed by /bin/wkhtmltopdf)\nError relocating /bin/wkhtmltopdf: ASN1_STRING_length: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_free: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_load_verify_locations: symbol not found\nError relocating /bin/wkhtmltopdf: BIO_new: symbol not found\nError relocating /bin/wkhtmltopdf: X509_getm_notAfter: symbol not found\nError relocating /bin/wkhtmltopdf: EVP_PKEY_free: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_read: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_set_default_verify_paths: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_free: symbol not found\nError relocating /bin/wkhtmltopdf: ASN1_STRING_data: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_clear: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_use_PrivateKey_file: symbol not found\nError relocating /bin/wkhtmltopdf: OBJ_obj2nid: symbol not found\nError relocating /bin/wkhtmltopdf: PEM_write_bio_RSAPrivateKey: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_CTX_free: symbol not found\nError relocating /bin/wkhtmltopdf: PEM_read_bio_DSAPrivateKey: symbol not found\nError relocating /bin/wkhtmltopdf: EVP_PKEY_base_id: symbol not found\nError relocating /bin/wkhtmltopdf: ERR_error_string: symbol not found\nError relocating /bin/wkhtmltopdf: X509_cmp: symbol not found\nError relocating /bin/wkhtmltopdf: EVP_PKEY_id: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_CTX_get_error: symbol not found\nError relocating /bin/wkhtmltopdf: OPENSSL_init_crypto: symbol not found\nError relocating /bin/wkhtmltopdf: X509_get_issuer_name: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_accept: symbol not found\nError relocating /bin/wkhtmltopdf: PEM_write_bio_DSA_PUBKEY: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_set_verify: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_CTX_set_purpose: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_new: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_write: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_CTX_use_certificate_file: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_get_current_cipher: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_free: symbol not found\nError relocating /bin/wkhtmltopdf: X509_get_serialNumber: symbol not found\nError relocating /bin/wkhtmltopdf: d2i_X509: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_get_peer_certificate: symbol not found\nError relocating /bin/wkhtmltopdf: X509_get_X509_PUBKEY: symbol not found\nError relocating /bin/wkhtmltopdf: PEM_read_bio_RSA_PUBKEY: symbol not found\nError relocating /bin/wkhtmltopdf: RAND_status: symbol not found\nError relocating /bin/wkhtmltopdf: RSA_free: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_CTX_new: symbol not found\nError relocating /bin/wkhtmltopdf: X509_verify_cert: symbol not found\nError relocating /bin/wkhtmltopdf: X509_STORE_CTX_get0_chain: symbol not found\nError relocating /bin/wkhtmltopdf: OPENSSL_sk_free: symbol not found\nError relocating /bin/wkhtmltopdf: X509_get_ext_d2i: symbol not found\nError relocating /bin/wkhtmltopdf: X509_get_version: symbol not found\nError relocating /bin/wkhtmltopdf: BN_num_bits: symbol not found\nError relocating /bin/wkhtmltopdf: OPENSSL_init_ssl: symbol not found\nError relocating /bin/wkhtmltopdf: X509_EXTENSION_get_object: symbol not found\nError relocating /bin/wkhtmltopdf: TLS_client_method: symbol not found\nError relocating /bin/wkhtmltopdf: SSL_get_ciphers: symbol not found\nError relocating /bin/wkhtmltopdf: BIO_write: symbol not found\nError relocating /bin/wkhtmltopdf: DSA_security_bits: symbol not found\nError relocating /bin/wkhtmltopdf: BIO_read: symbol not found\nError relocating /bin/wkhtmltopdf: EVP_PKEY_new: symbol not found\nError relocating /bin/wkhtmltopdf: ASN1_STRING_to_UTF8: symbol not foun" <> ...})
parzival_web  |         (pdf_generator 0.6.2) lib/pdf_generator.ex:316: PdfGenerator.generate_binary!/2
parzival_web  |         (phoenix_view 1.1.2) lib/phoenix/view.ex:475: Phoenix.View.render_to_iodata/3
parzival_web  |         (phoenix 1.6.10) lib/phoenix/controller.ex:772: Phoenix.Controller.render_and_send/4
parzival_web  |         (parzival 1.0.0-beta) lib/parzival_web/controllers/pdf_controller.ex:1: ParzivalWeb.PdfController.action/2
parzival_web  |         (parzival 1.0.0-beta) lib/parzival_web/controllers/pdf_controller.ex:1: ParzivalWeb.PdfController.phoenix_controller_pipeline/2
parzival_web  |         (phoenix 1.6.10) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
parzival_web  |         (parzival 1.0.0-beta) lib/parzival_web/endpoint.ex:1: ParzivalWeb.Endpoint.plug_builder_call/2
parzival_web  |         (parzival 1.0.0-beta) lib/plug/debugger.ex:136: ParzivalWeb.Endpoint."call (overridable 3)"/2
parzival_web  |         (parzival 1.0.0-beta) lib/parzival_web/endpoint.ex:1: ParzivalWeb.Endpoint.call/2
parzival_web  |         (phoenix 1.6.10) lib/phoenix/endpoint/cowboy2_handler.ex:54: Phoenix.Endpoint.Cowboy2Handler.init/4
parzival_web  |         (cowboy 2.9.0) /app/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
parzival_web  |         (cowboy 2.9.0) /app/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
parzival_web  |         (cowboy 2.9.0) /app/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
parzival_web  |         (stdlib 3.17.2.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3

```

Now this is fixed. Also dumped the image version to 1.14