### PR TITLE
Fix curriculum PDF issues

### DIFF
--- a/lib/parzival_web/templates/pdf/cv.html.heex
+++ b/lib/parzival_web/templates/pdf/cv.html.heex
@@ -37,8 +37,8 @@
     </style>
   </head>
 
-  <body style="background-color: white">
-    <div style="background-color: rgb(234,59,45); height: 37.13cm; z-index: -20;" class="absolute py-16 px-10 w-1/3">
+  <body style="background-color: white; margin: 0;">
+    <div style="background-color: rgb(234,59,45); height: 1460px; top: 0mm; left: 0mm; z-index: -20;" class="absolute py-16 px-10 w-1/3">
       <div class="relative mx-auto w-48 h-48">
         <%= if is_nil(@avatar) do %>
           <div style="background-color: rgb(234,59,45); border-width: 5px; border-color: white;" class="w-48 h-48 rounded-full border-white">

--- a/lib/parzival_web/templates/pdf/cv.html.heex
+++ b/lib/parzival_web/templates/pdf/cv.html.heex
@@ -241,25 +241,15 @@
               <tr class="mt-10 w-full">
                 <td>
                   <p style="color: rgb(234,59,45);" class="mb-4 text-2xl font-bold tracking-wider">SKILLS</p>
-                  <table>
-                    <tbody>
-                      <%= for chunk <- Enum.chunk_every(@curriculum.skills,4,4,[]) do %>
-                        <tr class="mt-1">
-                          <%= for skill <- chunk do %>
-                            <td class="w-36">
-                              <span style="border-bottom: rgb(234,59,45) 1.5px solid; border-top-style: none; border-left-style: none; border-right-style: none;">
-                                <%= if String.length(skill.name) <= 11 do %>
-                                  <%= skill.name %>
-                                <% else %>
-                                  <%= String.slice(skill.name, 0..10) <> "..." %>
-                                <% end %>
-                              </span>
-                            </td>
-                          <% end %>
-                        </tr>
+                    <div class="flex flex-wrap">
+                      <%= for skill <- @curriculum.skills do %>
+                        <div class="pr-8 pb-2">
+                          <span style="border-bottom: rgb(234,59,45) 1.5px solid;">
+                            <%= skill.name %>
+                          </span>
+                        </div>
                       <% end %>
-                    </tbody>
-                  </table>
+                    </div>
                 </td>
               </tr>
             <% end %>

--- a/lib/parzival_web/views/pdf_view.ex
+++ b/lib/parzival_web/views/pdf_view.ex
@@ -12,6 +12,7 @@ defmodule ParzivalWeb.PdfView do
       page_size: "A4",
       filename: "attendee_#{Ecto.UUID.generate()}.pdf",
       shell_params: [
+        "--disable-smart-shrinking",
         "--margin-top",
         "0",
         "--margin-left",


### PR DESCRIPTION
Changes skills display to space elements dynamically and left sidebar's height to fill full A4 page. Fixes #206

![image](https://github.com/joinum/parzival/assets/30907944/306e9285-4019-43cd-931e-f1c8e7920668)
