### PR TITLE
Remove 'in' text when user has no course

### DIFF
--- a/lib/parzival_web/live/backoffice/accounts/user_live/index.html.heex
+++ b/lib/parzival_web/live/backoffice/accounts/user_live/index.html.heex
@@ -77,7 +77,9 @@
                   <div class="text-gray-500">
                     <%= case @current_tab do %>
                       <% :attendee -> %>
-                        <%= user.cycle %> in <%= user.course %>
+                        <%= if not is_nil(user.cycle) and not is_nil(user.course) do %>
+                          <%= user.cycle %> in <%= user.course %>
+                        <% end %>
                       <% :recruiter -> %>
                         <%= user.company.name %>
                       <% _ -> %>


### PR DESCRIPTION
Fixes this:

![image](https://github.com/joinum/parzival/assets/30907944/31981182-af94-4c82-b649-c3842ff77ee5)
